### PR TITLE
feat-f : add mindle preview screens in bottom sheet

### DIFF
--- a/client/src/components/CreateMindle.js
+++ b/client/src/components/CreateMindle.js
@@ -9,6 +9,7 @@ import userState from '@contexts/userState';
 
 const Container = styled.View`
   flex: 1;
+  border-radius: 20px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/client/src/components/MindlePostContent.js
+++ b/client/src/components/MindlePostContent.js
@@ -1,0 +1,118 @@
+import React from 'react';
+import styled from 'styled-components/native';
+import { View, Text, TouchableOpacity } from 'react-native';
+
+const BoardContainer = styled.View`
+  height: 220px;
+
+  width: 100%;
+  padding: 10px 10px;
+  border-bottom-width: 1px;
+  border-bottom-color: black;
+`;
+const BoardUserInfo = styled.View`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+`;
+const BoardUserImageContainer = styled.TouchableOpacity`
+  width: 50px;
+  height: 50px;
+  padding: 5px 5px;
+  align-items: center;
+  justify-content: center;
+`;
+const BoardUserImage = styled.Image`
+  width: 40px;
+  height: 40px;
+`;
+const BoardUserName = styled.Text`
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 3px;
+`;
+const BoardContents = styled.View`
+  padding-top: 10px;
+  padding-left: 55px;
+`;
+const BoardContentTextContainer = styled.View`
+  height: 50px;
+  justify-content: flex-start;
+`;
+const BoardContentImageContainer = styled.View`
+  margin-top: 5px;
+  margin-bottom: 5px;
+  height: 55px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+const BoardContentImage = styled.View`
+  border: 1px solid black;
+  width: 70px;
+  height: 55px;
+  margin-right: 10px;
+`;
+const BoardTipContainer = styled.View`
+  height: 30px;
+  padding-top: 5px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+const MindlePostContent = ({
+  userPhoto,
+  userName,
+  date,
+  content,
+  photoContents,
+  likes,
+  commentsNum,
+  setMenuOpen = () => {},
+}) => {
+  return (
+    <>
+      <BoardContainer>
+        <BoardUserInfo>
+          <BoardUserImageContainer
+            onPress={() => {
+              setMenuOpen(true);
+            }}
+          >
+            <BoardUserImage source={{ uri: userPhoto }} />
+          </BoardUserImageContainer>
+          <View style={{ flex: 1, padding: 5 }}>
+            <BoardUserName
+              onPress={() => {
+                setMenuOpen(true);
+              }}
+            >
+              {userName}
+            </BoardUserName>
+            <Text>{date}</Text>
+          </View>
+        </BoardUserInfo>
+        <BoardContents>
+          <BoardContentTextContainer>
+            <Text>{content}</Text>
+          </BoardContentTextContainer>
+          <BoardContentImageContainer>
+            <BoardContentImage />
+            <BoardContentImage />
+            <BoardContentImage />
+          </BoardContentImageContainer>
+          <BoardTipContainer>
+            <TouchableOpacity>
+              <Text>Like {likes}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity>
+              <Text>Comments {commentsNum}</Text>
+            </TouchableOpacity>
+          </BoardTipContainer>
+        </BoardContents>
+      </BoardContainer>
+    </>
+  );
+};
+export default MindlePostContent;

--- a/client/src/components/Modal.js
+++ b/client/src/components/Modal.js
@@ -25,7 +25,6 @@ const Content = styled.View`
   border-radius: 20px;
   align-items: center;
   justify-content: center;
-  padding: 10px;
 `;
 const CustomModal = ({ width, height, modalVisible, setModalVisible, children }) => {
   return modalVisible ? (

--- a/client/src/components/Modal.js
+++ b/client/src/components/Modal.js
@@ -20,24 +20,25 @@ const BlackSpace = styled.View`
 
 const Content = styled.View`
   background-color: #ffffff;
-  width: 300px;
-  height: 250px;
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
   border-radius: 20px;
   align-items: center;
   justify-content: center;
   padding: 10px;
 `;
-const CustomModal = ({ modalVisible, setModalVisible, children }) => {
+const CustomModal = ({ width, height, modalVisible, setModalVisible, children }) => {
   return modalVisible ? (
     <Modal animationType={'fade'} transparent={true} visible={modalVisible}>
       <Container>
-        {/* <BlackSpace
+        <BlackSpace
           onTouchEnd={() => {
             setModalVisible(false);
           }}
-        > */}
-        <Content>{children}</Content>
-        {/* </BlackSpace> */}
+        ></BlackSpace>
+        <Content width={width ? width : '300px'} height={height ? height : '250px'}>
+          {children}
+        </Content>
       </Container>
     </Modal>
   ) : null;

--- a/client/src/screens/Maps.js
+++ b/client/src/screens/Maps.js
@@ -9,6 +9,7 @@ import axios from 'axios';
 import BottomSheet from 'reanimated-bottom-sheet';
 import Animated from 'react-native-reanimated';
 import CreateMindle from '@components/CreateMindle';
+import MindlePreview from '@screens/MindlePreview';
 import MindleInfo from '@screens/MindleInfo';
 import { useRecoilValue } from 'recoil';
 import userState from '@contexts/userState';
@@ -80,7 +81,15 @@ const Maps = ({ navigation }) => {
   const renderInner = () =>
     clickedMindleInfo && (
       <View style={{ height: '100%' }}>
-        <MindleInfo key={clickedMindleInfo.key} name={clickedMindleInfo.name} overlap={clickedMindleInfo.overlap} />
+        {clickedMindleInfo.overlap ? (
+          <MindleInfo key={clickedMindleInfo.key} name={clickedMindleInfo.name} overlap={clickedMindleInfo.overlap} />
+        ) : (
+          <MindlePreview
+            key={clickedMindleInfo.key}
+            name={clickedMindleInfo.name}
+            overlap={clickedMindleInfo.overlap}
+          />
+        )}
       </View>
     );
 

--- a/client/src/screens/Maps.js
+++ b/client/src/screens/Maps.js
@@ -80,7 +80,7 @@ const Maps = ({ navigation }) => {
   const renderInner = () =>
     clickedMindleInfo && (
       <View style={{ height: '100%' }}>
-        <MindleInfo key={clickedMindleInfo.key} name={clickedMindleInfo.name} />
+        <MindleInfo key={clickedMindleInfo.key} name={clickedMindleInfo.name} overlap={clickedMindleInfo.overlap} />
       </View>
     );
 
@@ -288,6 +288,7 @@ const Maps = ({ navigation }) => {
       description: mindle.description || '민들레 설명 데이터 없음',
       visitCount: 18, //데이터 필요
       current: 1, //데이터 필요
+      overlap: mindle.overlap,
     });
     console.log(mindle);
   };

--- a/client/src/screens/Maps.js
+++ b/client/src/screens/Maps.js
@@ -82,10 +82,14 @@ const Maps = ({ navigation }) => {
     clickedMindleInfo && (
       <View style={{ height: '100%' }}>
         {clickedMindleInfo.overlap ? (
-          <MindleInfo key={clickedMindleInfo.key} name={clickedMindleInfo.name} overlap={clickedMindleInfo.overlap} />
+          <MindleInfo
+            mindleKey={clickedMindleInfo.key}
+            name={clickedMindleInfo.name}
+            overlap={clickedMindleInfo.overlap}
+          />
         ) : (
           <MindlePreview
-            key={clickedMindleInfo.key}
+            mindleKey={clickedMindleInfo.key}
             name={clickedMindleInfo.name}
             overlap={clickedMindleInfo.overlap}
           />

--- a/client/src/screens/Maps.js
+++ b/client/src/screens/Maps.js
@@ -41,6 +41,7 @@ const Maps = ({ navigation }) => {
   const fall = new Animated.Value(2);
   const [modalVisible, setModalVisible] = useState(false);
   const [clickedMindleInfo, setClickedMindleInfo] = useState({
+    key: '',
     name: '',
     madeby: '',
     description: [],
@@ -76,11 +77,12 @@ const Maps = ({ navigation }) => {
   //지도에 표시하기 위한 민들레 값들을 저장하는 변수
   //TODO : useMemo
   const [mindles, setMindles] = useState([]);
-  const renderInner = () => (
-    <View style={{ height: '100%' }}>
-      <MindleInfo mindleInfo={clickedMindleInfo} />
-    </View>
-  );
+  const renderInner = () =>
+    clickedMindleInfo && (
+      <View style={{ height: '100%' }}>
+        <MindleInfo key={clickedMindleInfo.key} name={clickedMindleInfo.name} />
+      </View>
+    );
 
   //API 기준 좌표
   const [mindleBaseCoord, setMindleBaseCoord] = useState({
@@ -280,12 +282,14 @@ const Maps = ({ navigation }) => {
 
   const getClickedMindleInfo = (mindle) => {
     setClickedMindleInfo({
+      key: mindle.key,
       name: mindle.title,
       madeby: '창시자', //데이터 필요
       description: mindle.description || '민들레 설명 데이터 없음',
       visitCount: 18, //데이터 필요
       current: 1, //데이터 필요
     });
+    console.log(mindle);
   };
 
   return (

--- a/client/src/screens/MindleInfo.js
+++ b/client/src/screens/MindleInfo.js
@@ -3,6 +3,7 @@ import styled from 'styled-components/native';
 import { View, Text, TouchableOpacity, ActivityIndicator, Alert } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import ProfileModal from '@components/Modal';
+import BoardContent from '@components/MindlePostContent';
 
 const Container = styled.SafeAreaView`
   flex: 1;
@@ -32,64 +33,6 @@ const Image = styled.View`
   margin: 5px;
 `;
 
-const BoardContainer = styled.View`
-  height: 220px;
-
-  width: 100%;
-  padding: 10px 10px;
-  border-bottom-width: 1px;
-  border-bottom-color: black;
-`;
-const BoardUserInfo = styled.View`
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-`;
-const BoardUserImageContainer = styled.TouchableOpacity`
-  width: 50px;
-  height: 50px;
-  padding: 5px 5px;
-  align-items: center;
-  justify-content: center;
-`;
-const BoardUserImage = styled.Image`
-  width: 40px;
-  height: 40px;
-`;
-const BoardUserName = styled.Text`
-  font-size: 14px;
-  font-weight: 600;
-  margin-bottom: 3px;
-`;
-const BoardContents = styled.View`
-  padding-top: 10px;
-  padding-left: 55px;
-`;
-const BoardContentTextContainer = styled.View`
-  height: 50px;
-  justify-content: flex-start;
-`;
-const BoardContentImageContainer = styled.View`
-  margin-top: 5px;
-  margin-bottom: 5px;
-  height: 55px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`;
-const BoardContentImage = styled.View`
-  border: 1px solid black;
-  width: 70px;
-  height: 55px;
-  margin-right: 10px;
-`;
-const BoardTipContainer = styled.View`
-  height: 30px;
-  padding-top: 5px;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-`;
 const Tab = styled.View`
   display: flex;
   flex-direction: row;
@@ -98,51 +41,6 @@ const Tab = styled.View`
   padding: 5px;
   justify-content: space-evenly;
 `;
-const BoardContent = ({ userPhoto, userName, date, content, photoContents, likes, commentsNum, setMenuOpen }) => {
-  return (
-    <>
-      <BoardContainer>
-        <BoardUserInfo>
-          <BoardUserImageContainer
-            onPress={() => {
-              setMenuOpen(true);
-            }}
-          >
-            <BoardUserImage source={{ uri: userPhoto }} />
-          </BoardUserImageContainer>
-          <View style={{ flex: 1, padding: 5 }}>
-            <BoardUserName
-              onPress={() => {
-                setMenuOpen(true);
-              }}
-            >
-              {userName}
-            </BoardUserName>
-            <Text>{date}</Text>
-          </View>
-        </BoardUserInfo>
-        <BoardContents>
-          <BoardContentTextContainer>
-            <Text>{content}</Text>
-          </BoardContentTextContainer>
-          <BoardContentImageContainer>
-            <BoardContentImage />
-            <BoardContentImage />
-            <BoardContentImage />
-          </BoardContentImageContainer>
-          <BoardTipContainer>
-            <TouchableOpacity>
-              <Text>Like {likes}</Text>
-            </TouchableOpacity>
-            <TouchableOpacity>
-              <Text>Comments {commentsNum}</Text>
-            </TouchableOpacity>
-          </BoardTipContainer>
-        </BoardContents>
-      </BoardContainer>
-    </>
-  );
-};
 
 const MindleInfo = ({ mindleKey, name, overlap }) => {
   const [menuOpen, setMenuOpen] = useState(false);

--- a/client/src/screens/MindleInfo.js
+++ b/client/src/screens/MindleInfo.js
@@ -2,6 +2,7 @@ import React, { useRef, useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components/native';
 import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
+import ProfileModal from '@components/Modal';
 
 const Container = styled.SafeAreaView`
   flex: 1;
@@ -44,7 +45,7 @@ const BoardUserInfo = styled.View`
   display: flex;
   flex-direction: row;
 `;
-const BoardUserImageContainer = styled.View`
+const BoardUserImageContainer = styled.TouchableOpacity`
   width: 50px;
   height: 50px;
   padding: 5px 5px;
@@ -97,16 +98,26 @@ const Tab = styled.View`
   padding: 5px;
   justify-content: space-evenly;
 `;
-const BoardContent = ({ userPhoto, userName, date, content, photoContents, likes, commentsNum }) => {
+const BoardContent = ({ userPhoto, userName, date, content, photoContents, likes, commentsNum, setMenuOpen }) => {
   return (
     <>
       <BoardContainer>
         <BoardUserInfo>
-          <BoardUserImageContainer>
+          <BoardUserImageContainer
+            onPress={() => {
+              setMenuOpen(true);
+            }}
+          >
             <BoardUserImage source={{ uri: userPhoto }} />
           </BoardUserImageContainer>
           <View style={{ flex: 1, padding: 5 }}>
-            <BoardUserName>{userName}</BoardUserName>
+            <BoardUserName
+              onPress={() => {
+                setMenuOpen(true);
+              }}
+            >
+              {userName}
+            </BoardUserName>
             <Text>{date}</Text>
           </View>
         </BoardUserInfo>
@@ -133,7 +144,8 @@ const BoardContent = ({ userPhoto, userName, date, content, photoContents, likes
   );
 };
 
-const MindleInfo = ({ key, name, overlap }) => {
+const MindleInfo = ({ mindleKey, name, overlap }) => {
+  const [menuOpen, setMenuOpen] = useState(false);
   const [page, setPage] = useState(0);
   const [tabIndex, setTabIndex] = useState(0);
   const [data, setData] = useState([]);
@@ -222,6 +234,7 @@ const MindleInfo = ({ key, name, overlap }) => {
       commentsNum: 71,
     },
   ]);
+
   useEffect(() => {
     console.log(overlap);
     setLoading(true);
@@ -234,7 +247,7 @@ const MindleInfo = ({ key, name, overlap }) => {
     return () => {
       setData(null);
     };
-  }, [key]);
+  }, [mindleKey]);
 
   useEffect(() => {
     //TODO : data 불러왔는지 확인 후 안불러왔으면 로딩, 데이터 불러오기
@@ -255,6 +268,7 @@ const MindleInfo = ({ key, name, overlap }) => {
           photoContents={item.photoContents}
           likes={item.likes}
           commentsNum={item.commentsNum}
+          setMenuOpen={setMenuOpen}
         />
       </>
     ),
@@ -375,6 +389,12 @@ const MindleInfo = ({ key, name, overlap }) => {
             <ActivityIndicator size="large" color="0000ff" />
           </View>
         )}
+
+        <ProfileModal width={'200px'} height={'50px'} modalVisible={menuOpen} setModalVisible={setMenuOpen}>
+          <View style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Text style={{ fontSize: 18 }}>쪽지 보내기</Text>
+          </View>
+        </ProfileModal>
       </Container>
     </>
   );

--- a/client/src/screens/MindleInfo.js
+++ b/client/src/screens/MindleInfo.js
@@ -128,120 +128,115 @@ const BoardContent = ({ userPhoto, userName, date, content, photoContents, likes
     </>
   );
 };
-const DATA = [
-  {
-    userPhoto:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-    userName: '부끄러운 개',
-    date: '2021-09-21',
-    content: '부끄러운 개님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-    photoContents: ['', ''],
-    likes: 20,
-    commentsNum: 17,
-  },
-  {
-    userPhoto:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-    userName: '즐거운 세숑',
-    date: '2021-09-21',
-    content: '즐거운 세숑님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-    photoContents: ['', ''],
-    likes: 14,
-    commentsNum: 11,
-  },
-  {
-    userPhoto:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-    userName: '미친 고릴라',
-    date: '2021-09-20',
-    content: '미친 고릴라님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-    photoContents: ['', ''],
-    likes: 17,
-    commentsNum: 12,
-  },
 
-  {
-    userPhoto:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-    userName: '성난 닭',
-    date: '2021-09-19',
-    content: '성난 닭님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-    photoContents: ['', ''],
-    likes: 8,
-    commentsNum: 6,
-  },
-  {
-    userPhoto:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-    userName: '살찐 황소',
-    date: '2021-09-19',
-    content: '살찐 황소님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-    photoContents: ['', ''],
-    likes: 11,
-    commentsNum: 9,
-  },
-  {
-    userPhoto:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-    userName: '신난 어피치',
-    date: '2021-09-18',
-    content: '신난 어피치님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-    photoContents: ['', ''],
-    likes: 2,
-    commentsNum: 1,
-  },
-
-  {
-    userPhoto:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-    userName: '상큼한 무지',
-    date: '2021-09-18',
-    content: '상큼한 무지님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-    photoContents: ['', ''],
-    likes: 6,
-    commentsNum: 4,
-  },
-  {
-    userPhoto:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-    userName: '화난 라이언',
-    date: '2021-09-17',
-    content: '화난 라이언님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-    photoContents: ['', ''],
-    likes: 51,
-    commentsNum: 71,
-  },
-];
-const MindleInfo = (props) => {
+const MindleInfo = ({ key, name }) => {
   const [page, setPage] = useState(0);
-  const [mindleInfo, setMindleInfo] = useState({ name: '', madeby: '', description: '', visitCount: '', current: '' });
-
-  const [tabIndex, setTabIndex] = useState(null);
+  const [tabIndex, setTabIndex] = useState(0);
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [inMindle, setInMindle] = useState();
+  const [DATA, setDATA] = useState([
+    {
+      userPhoto:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+      userName: '부끄러운 개',
+      date: '2021-09-21',
+      content: '부끄러운 개님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+      photoContents: ['', ''],
+      likes: 20,
+      commentsNum: 17,
+    },
+    {
+      userPhoto:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+      userName: '즐거운 세숑',
+      date: '2021-09-21',
+      content: '즐거운 세숑님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+      photoContents: ['', ''],
+      likes: 14,
+      commentsNum: 11,
+    },
+    {
+      userPhoto:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+      userName: '미친 고릴라',
+      date: '2021-09-20',
+      content: '미친 고릴라님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+      photoContents: ['', ''],
+      likes: 17,
+      commentsNum: 12,
+    },
 
+    {
+      userPhoto:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+      userName: '성난 닭',
+      date: '2021-09-19',
+      content: '성난 닭님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+      photoContents: ['', ''],
+      likes: 8,
+      commentsNum: 6,
+    },
+    {
+      userPhoto:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+      userName: '살찐 황소',
+      date: '2021-09-19',
+      content: '살찐 황소님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+      photoContents: ['', ''],
+      likes: 11,
+      commentsNum: 9,
+    },
+    {
+      userPhoto:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+      userName: '신난 어피치',
+      date: '2021-09-18',
+      content: '신난 어피치님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+      photoContents: ['', ''],
+      likes: 2,
+      commentsNum: 1,
+    },
+
+    {
+      userPhoto:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+      userName: '상큼한 무지',
+      date: '2021-09-18',
+      content: '상큼한 무지님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+      photoContents: ['', ''],
+      likes: 6,
+      commentsNum: 4,
+    },
+    {
+      userPhoto:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+      userName: '화난 라이언',
+      date: '2021-09-17',
+      content: '화난 라이언님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+      photoContents: ['', ''],
+      likes: 51,
+      commentsNum: 71,
+    },
+  ]);
   useEffect(() => {
     setLoading(true);
-    setInMindle(true);
-    setMindleInfo(props.mindleInfo);
-    setTabIndex(0);
     setData(DATA.splice(0, 3));
     setPage((prev) => prev + 1);
     setTimeout(() => {
-      if (mindleInfo) console.log(mindleInfo);
       setLoading(false);
-    }, 1000);
-    //setLoading(true);
-    //getData();
-  }, []);
+    }, 500);
+
+    return () => {
+      setData(null);
+    };
+  }, [key]);
 
   useEffect(() => {
     //TODO : data 불러왔는지 확인 후 안불러왔으면 로딩, 데이터 불러오기
     setLoading(true);
     setTimeout(() => {
       setLoading(false);
-    }, 1000);
+    }, 500);
   }, [tabIndex]);
 
   const renderItem = useCallback(
@@ -264,7 +259,7 @@ const MindleInfo = (props) => {
   const getData = (callback) => {
     //TODO : get contents API
     try {
-      const newData = DATA.splice(0, 3);
+      const newData = DATA.spice(0, 3);
       setData((prev) => [...prev, ...newData]);
       setPage((prev) => prev + 1);
       callback(newData);

--- a/client/src/screens/MindleInfo.js
+++ b/client/src/screens/MindleInfo.js
@@ -317,6 +317,7 @@ const MindleInfo = ({ key, name, overlap }) => {
             <Text>이벤트</Text>
           </TouchableOpacity>
         </Tab>
+
         <Divider />
         {!loading && overlap && (
           <>
@@ -336,16 +337,18 @@ const MindleInfo = ({ key, name, overlap }) => {
               onEndReachedThreshold={0.2}
               ListHeaderComponent={() => (
                 <>
-                  <ImageContainer>
-                    <Image></Image>
-                    <Image></Image>
-                    <Image></Image>
-                    <Image></Image>
-                    <Image></Image>
-                    <Image></Image>
-                    <Image></Image>
-                    <Image></Image>
-                  </ImageContainer>
+                  {tabIndex === 0 && (
+                    <ImageContainer>
+                      <Image></Image>
+                      <Image></Image>
+                      <Image></Image>
+                      <Image></Image>
+                      <Image></Image>
+                      <Image></Image>
+                      <Image></Image>
+                      <Image></Image>
+                    </ImageContainer>
+                  )}
                 </>
               )}
             />
@@ -367,7 +370,11 @@ const MindleInfo = ({ key, name, overlap }) => {
             </TouchableOpacity>
           </>
         )}
-        {loading && <ActivityIndicator size="large" color="0000ff" />}
+        {loading && (
+          <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+            <ActivityIndicator size="large" color="0000ff" />
+          </View>
+        )}
       </Container>
     </>
   );

--- a/client/src/screens/MindleInfo.js
+++ b/client/src/screens/MindleInfo.js
@@ -1,9 +1,9 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components/native';
 import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 
-const Container = styled.View`
+const Container = styled.SafeAreaView`
   flex: 1;
   display: flex;
   padding: 15px 15px;
@@ -32,9 +32,11 @@ const Image = styled.View`
 `;
 
 const BoardContainer = styled.View`
-  flex: 1;
   height: 220px;
+  width: 100%;
   padding: 10px 10px;
+  border-bottom-width: 1px;
+  border-bottom-color: black;
 `;
 const BoardUserInfo = styled.View`
   width: 100%;
@@ -126,93 +128,93 @@ const BoardContent = ({ userPhoto, userName, date, content, photoContents, likes
     </>
   );
 };
+const DATA = [
+  {
+    userPhoto:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+    userName: '부끄러운 개',
+    date: '2021-09-21',
+    content: '부끄러운 개님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+    photoContents: ['', ''],
+    likes: 20,
+    commentsNum: 17,
+  },
+  {
+    userPhoto:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+    userName: '즐거운 세숑',
+    date: '2021-09-21',
+    content: '즐거운 세숑님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+    photoContents: ['', ''],
+    likes: 14,
+    commentsNum: 11,
+  },
+  {
+    userPhoto:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+    userName: '미친 고릴라',
+    date: '2021-09-20',
+    content: '미친 고릴라님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+    photoContents: ['', ''],
+    likes: 17,
+    commentsNum: 12,
+  },
+
+  {
+    userPhoto:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+    userName: '성난 닭',
+    date: '2021-09-19',
+    content: '성난 닭님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+    photoContents: ['', ''],
+    likes: 8,
+    commentsNum: 6,
+  },
+  {
+    userPhoto:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+    userName: '살찐 황소',
+    date: '2021-09-19',
+    content: '살찐 황소님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+    photoContents: ['', ''],
+    likes: 11,
+    commentsNum: 9,
+  },
+  {
+    userPhoto:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+    userName: '신난 어피치',
+    date: '2021-09-18',
+    content: '신난 어피치님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+    photoContents: ['', ''],
+    likes: 2,
+    commentsNum: 1,
+  },
+
+  {
+    userPhoto:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+    userName: '상큼한 무지',
+    date: '2021-09-18',
+    content: '상큼한 무지님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+    photoContents: ['', ''],
+    likes: 6,
+    commentsNum: 4,
+  },
+  {
+    userPhoto:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+    userName: '화난 라이언',
+    date: '2021-09-17',
+    content: '화난 라이언님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+    photoContents: ['', ''],
+    likes: 51,
+    commentsNum: 71,
+  },
+];
 const MindleInfo = (props) => {
   const [page, setPage] = useState(0);
   const [mindleInfo, setMindleInfo] = useState({ name: '', madeby: '', description: '', visitCount: '', current: '' });
-  let DATA = [
-    {
-      userPhoto:
-        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-      userName: '부끄러운 개',
-      date: '2021-09-21',
-      content: '부끄러운 개님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-      photoContents: ['', ''],
-      likes: 20,
-      commentsNum: 17,
-    },
-    {
-      userPhoto:
-        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-      userName: '즐거운 세숑',
-      date: '2021-09-21',
-      content: '즐거운 세숑님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-      photoContents: ['', ''],
-      likes: 14,
-      commentsNum: 11,
-    },
-    {
-      userPhoto:
-        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-      userName: '미친 고릴라',
-      date: '2021-09-20',
-      content: '미친 고릴라님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-      photoContents: ['', ''],
-      likes: 17,
-      commentsNum: 12,
-    },
-
-    {
-      userPhoto:
-        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-      userName: '성난 닭',
-      date: '2021-09-19',
-      content: '성난 닭님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-      photoContents: ['', ''],
-      likes: 8,
-      commentsNum: 6,
-    },
-    {
-      userPhoto:
-        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-      userName: '살찐 황소',
-      date: '2021-09-19',
-      content: '살찐 황소님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-      photoContents: ['', ''],
-      likes: 11,
-      commentsNum: 9,
-    },
-    {
-      userPhoto:
-        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-      userName: '신난 어피치',
-      date: '2021-09-18',
-      content: '신난 어피치님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-      photoContents: ['', ''],
-      likes: 2,
-      commentsNum: 1,
-    },
-
-    {
-      userPhoto:
-        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-      userName: '상큼한 무지',
-      date: '2021-09-18',
-      content: '상큼한 무지님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-      photoContents: ['', ''],
-      likes: 6,
-      commentsNum: 4,
-    },
-    {
-      userPhoto:
-        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
-      userName: '화난 라이언',
-      date: '2021-09-17',
-      content: '화난 라이언님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
-      photoContents: ['', ''],
-      likes: 51,
-      commentsNum: 71,
-    },
-  ];
 
   const [tabIndex, setTabIndex] = useState(null);
   const [data, setData] = useState([]);
@@ -224,11 +226,12 @@ const MindleInfo = (props) => {
     setInMindle(true);
     setMindleInfo(props.mindleInfo);
     setTabIndex(0);
-    setData(DATA);
+    setData(DATA.splice(0, 3));
+    setPage((prev) => prev + 1);
     setTimeout(() => {
       if (mindleInfo) console.log(mindleInfo);
       setLoading(false);
-    }, 2000);
+    }, 1000);
     //setLoading(true);
     //getData();
   }, []);
@@ -240,8 +243,9 @@ const MindleInfo = (props) => {
       setLoading(false);
     }, 1000);
   }, [tabIndex]);
-  const renderItem = ({ item }) => {
-    return (
+
+  const renderItem = useCallback(
+    ({ item }) => (
       <>
         <BoardContent
           userPhoto={item.userPhoto}
@@ -253,26 +257,31 @@ const MindleInfo = (props) => {
           commentsNum={item.commentsNum}
         />
       </>
-    );
-  };
+    ),
+    [],
+  );
 
-  const getData = () => {
+  const getData = (callback) => {
     //TODO : get contents API
-    if (page < DATA.length) {
-      console.log('get data');
-      let newData = DATA[page];
+    try {
+      const newData = DATA.splice(0, 3);
       setData((prev) => [...prev, ...newData]);
-      setPage(page + 1);
-    } else {
-      console.log('No more data');
+      setPage((prev) => prev + 1);
+      callback(newData);
+    } catch (e) {
+      const newData = DATA.splice(0, DATA.length);
+      setData((prev) => [...prev, ...newData]);
+      setPage((prev) => prev + 1);
+      callback(newData);
     }
-    setLoading(false);
   };
 
   const handleLoadMore = () => {
     console.log('load more!');
     setLoading(true);
-    getData();
+    getData((newData) => {
+      if (newData) setLoading(false);
+    });
   };
 
   return (
@@ -281,7 +290,6 @@ const MindleInfo = (props) => {
         {/* <Header /> */}
         {!loading && (
           <FlatList
-            style={{ zIndex: 1 }}
             data={tabIndex === 0 ? data : [0]}
             renderItem={
               tabIndex === 0
@@ -293,8 +301,8 @@ const MindleInfo = (props) => {
                   )
             }
             keyExtractor={(item, idx) => String(idx)}
-            //onEndReached={handleLoadMore}
-            //onEndReachedThreshold={0.4}
+            onEndReached={handleLoadMore}
+            onEndReachedThreshold={0.2}
             ListHeaderComponent={() => (
               <>
                 <ImageContainer>

--- a/client/src/screens/MindleInfo.js
+++ b/client/src/screens/MindleInfo.js
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components/native';
-import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { View, Text, TouchableOpacity, ActivityIndicator, Alert } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import ProfileModal from '@components/Modal';
 
@@ -15,8 +15,8 @@ const Container = styled.SafeAreaView`
 
 const Divider = styled.View`
   margin-top: 10px;
-  height: 0.5px;
-  border: 0.5px solid #000000;
+  height: 1px;
+  border: 0.3px solid #000000;
 `;
 const ImageContainer = styled.View`
   display: flex;
@@ -390,9 +390,55 @@ const MindleInfo = ({ mindleKey, name, overlap }) => {
           </View>
         )}
 
-        <ProfileModal width={'200px'} height={'50px'} modalVisible={menuOpen} setModalVisible={setMenuOpen}>
-          <View style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Text style={{ fontSize: 18 }}>쪽지 보내기</Text>
+        <ProfileModal width="180px" height="100px" modalVisible={menuOpen} setModalVisible={setMenuOpen}>
+          <View
+            style={{
+              width: '100%',
+              height: '100%',
+              justifyContent: 'space-evenly',
+              padding: 5,
+            }}
+          >
+            <View
+              style={{
+                flex: 1,
+                borderTopLeftRadius: 20,
+                borderTopRightRadius: 20,
+                width: '100%',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <TouchableOpacity
+                style={{ justifyContent: 'center' }}
+                onPress={() => {
+                  Alert.alert('쪽지 보내기', '쪽지 보내기 화면으로 이동');
+                }}
+              >
+                <Text style={{ fontSize: 16 }}>쪽지 보내기</Text>
+              </TouchableOpacity>
+            </View>
+            <Divider />
+            <View
+              style={{
+                flex: 1,
+                borderBottomLeftRadius: 20,
+                borderBottomRightRadius: 20,
+                width: '100%',
+                marginTop: 5,
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <TouchableOpacity
+                onPress={() => {
+                  setMenuOpen(false);
+                }}
+                style={{ justifyContent: 'center' }}
+              >
+                <Text style={{ fontSize: 16, color: 'red' }}>닫기</Text>
+              </TouchableOpacity>
+            </View>
           </View>
         </ProfileModal>
       </Container>

--- a/client/src/screens/MindleInfo.js
+++ b/client/src/screens/MindleInfo.js
@@ -410,7 +410,7 @@ const MindleInfo = ({ mindleKey, name, overlap }) => {
               }}
             >
               <TouchableOpacity
-                style={{ justifyContent: 'center' }}
+                style={{ alignItems: 'center', justifyContent: 'center', width: '100%' }}
                 onPress={() => {
                   Alert.alert('쪽지 보내기', '쪽지 보내기 화면으로 이동');
                 }}
@@ -434,7 +434,7 @@ const MindleInfo = ({ mindleKey, name, overlap }) => {
                 onPress={() => {
                   setMenuOpen(false);
                 }}
-                style={{ justifyContent: 'center' }}
+                style={{ alignItems: 'center', justifyContent: 'center', width: '100%' }}
               >
                 <Text style={{ fontSize: 16, color: 'red' }}>닫기</Text>
               </TouchableOpacity>

--- a/client/src/screens/MindleInfo.js
+++ b/client/src/screens/MindleInfo.js
@@ -9,12 +9,12 @@ const Container = styled.SafeAreaView`
   padding: 15px 15px;
   height: 100%;
   background-color: #ffffff;
-  justify-content: center;
+  justify-content: flex-start;
 `;
 
 const Divider = styled.View`
   margin-top: 10px;
-  height: 1px;
+  height: 0.5px;
   border: 0.5px solid #000000;
 `;
 const ImageContainer = styled.View`
@@ -33,6 +33,7 @@ const Image = styled.View`
 
 const BoardContainer = styled.View`
   height: 220px;
+
   width: 100%;
   padding: 10px 10px;
   border-bottom-width: 1px;
@@ -60,7 +61,6 @@ const BoardUserName = styled.Text`
   margin-bottom: 3px;
 `;
 const BoardContents = styled.View`
-  flex: 1;
   padding-top: 10px;
   padding-left: 55px;
 `;
@@ -120,8 +120,12 @@ const BoardContent = ({ userPhoto, userName, date, content, photoContents, likes
             <BoardContentImage />
           </BoardContentImageContainer>
           <BoardTipContainer>
-            <Text>Like {likes}</Text>
-            <Text>Cormments {commentsNum}</Text>
+            <TouchableOpacity>
+              <Text>Like {likes}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity>
+              <Text>Comments {commentsNum}</Text>
+            </TouchableOpacity>
           </BoardTipContainer>
         </BoardContents>
       </BoardContainer>
@@ -129,7 +133,7 @@ const BoardContent = ({ userPhoto, userName, date, content, photoContents, likes
   );
 };
 
-const MindleInfo = ({ key, name }) => {
+const MindleInfo = ({ key, name, overlap }) => {
   const [page, setPage] = useState(0);
   const [tabIndex, setTabIndex] = useState(0);
   const [data, setData] = useState([]);
@@ -219,6 +223,7 @@ const MindleInfo = ({ key, name }) => {
     },
   ]);
   useEffect(() => {
+    console.log(overlap);
     setLoading(true);
     setData(DATA.splice(0, 3));
     setPage((prev) => prev + 1);
@@ -283,65 +288,84 @@ const MindleInfo = ({ key, name }) => {
     <>
       <Container>
         {/* <Header /> */}
-        {!loading && (
-          <FlatList
-            data={tabIndex === 0 ? data : [0]}
-            renderItem={
-              tabIndex === 0
-                ? renderItem
-                : () => (
-                    <View>
-                      <Text>이벤트 목록</Text>
-                    </View>
-                  )
-            }
-            keyExtractor={(item, idx) => String(idx)}
-            onEndReached={handleLoadMore}
-            onEndReachedThreshold={0.2}
-            ListHeaderComponent={() => (
-              <>
-                <ImageContainer>
-                  <Image></Image>
-                  <Image></Image>
-                  <Image></Image>
-                  <Image></Image>
-                  <Image></Image>
-                  <Image></Image>
-                  <Image></Image>
-                  <Image></Image>
-                </ImageContainer>
-                <Divider />
-                <Tab>
-                  <TouchableOpacity
-                    onPress={() => {
-                      setTabIndex(0);
-                    }}
-                    style={{
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      width: '50%',
-                      backgroundColor: tabIndex === 0 ? '#bdbdbd' : '#fefefe',
-                    }}
-                  >
-                    <Text>게시글</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    onPress={() => {
-                      setTabIndex(1);
-                    }}
-                    style={{
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      width: '50%',
-                      backgroundColor: tabIndex === 0 ? '#fefefe' : '#bdbdbd',
-                    }}
-                  >
-                    <Text>이벤트</Text>
-                  </TouchableOpacity>
-                </Tab>
-              </>
-            )}
-          />
+
+        <Tab>
+          <TouchableOpacity
+            onPress={() => {
+              setTabIndex(0);
+            }}
+            style={{
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '50%',
+              backgroundColor: tabIndex === 0 ? '#bdbdbd' : '#fefefe',
+            }}
+          >
+            <Text>게시글</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => {
+              setTabIndex(1);
+            }}
+            style={{
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '50%',
+              backgroundColor: tabIndex === 0 ? '#fefefe' : '#bdbdbd',
+            }}
+          >
+            <Text>이벤트</Text>
+          </TouchableOpacity>
+        </Tab>
+        <Divider />
+        {!loading && overlap && (
+          <>
+            <FlatList
+              data={tabIndex === 0 ? data : [0]}
+              renderItem={
+                tabIndex === 0
+                  ? renderItem
+                  : () => (
+                      <View>
+                        <Text>이벤트 목록</Text>
+                      </View>
+                    )
+              }
+              keyExtractor={(item, idx) => String(idx)}
+              onEndReached={handleLoadMore}
+              onEndReachedThreshold={0.2}
+              ListHeaderComponent={() => (
+                <>
+                  <ImageContainer>
+                    <Image></Image>
+                    <Image></Image>
+                    <Image></Image>
+                    <Image></Image>
+                    <Image></Image>
+                    <Image></Image>
+                    <Image></Image>
+                    <Image></Image>
+                  </ImageContainer>
+                </>
+              )}
+            />
+            <TouchableOpacity
+              style={{
+                width: 60,
+                height: 60,
+                position: 'absolute',
+                top: '90%',
+                right: '5%',
+                alignSelf: 'flex-end',
+                borderWidth: 1,
+                borderRadius: 50,
+                justifyContent: 'center',
+                backgroundColor: '#dbdbdb',
+              }}
+            >
+              <Text style={{ alignSelf: 'center', fontSize: 30 }}>+</Text>
+            </TouchableOpacity>
+          </>
         )}
         {loading && <ActivityIndicator size="large" color="0000ff" />}
       </Container>

--- a/client/src/screens/MindlePreview.js
+++ b/client/src/screens/MindlePreview.js
@@ -1,7 +1,7 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components/native';
 import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
-import { FlatList } from 'react-native-gesture-handler';
+import BoardContent from '@components/MindlePostContent';
 
 const Container = styled.SafeAreaView`
   flex: 1;
@@ -31,64 +31,6 @@ const Image = styled.View`
   margin: 5px;
 `;
 
-const BoardContainer = styled.View`
-  height: 220px;
-
-  width: 100%;
-  padding: 10px 10px;
-  border-bottom-width: 1px;
-  border-bottom-color: black;
-`;
-const BoardUserInfo = styled.View`
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-`;
-const BoardUserImageContainer = styled.View`
-  width: 50px;
-  height: 50px;
-  padding: 5px 5px;
-  align-items: center;
-  justify-content: center;
-`;
-const BoardUserImage = styled.Image`
-  width: 40px;
-  height: 40px;
-`;
-const BoardUserName = styled.Text`
-  font-size: 14px;
-  font-weight: 600;
-  margin-bottom: 3px;
-`;
-const BoardContents = styled.View`
-  padding-top: 10px;
-  padding-left: 55px;
-`;
-const BoardContentTextContainer = styled.View`
-  height: 50px;
-  justify-content: flex-start;
-`;
-const BoardContentImageContainer = styled.View`
-  margin-top: 5px;
-  margin-bottom: 5px;
-  height: 55px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`;
-const BoardContentImage = styled.View`
-  border: 1px solid black;
-  width: 70px;
-  height: 55px;
-  margin-right: 10px;
-`;
-const BoardTipContainer = styled.View`
-  height: 30px;
-  padding-top: 5px;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-`;
 const Tab = styled.View`
   display: flex;
   flex-direction: row;
@@ -97,41 +39,6 @@ const Tab = styled.View`
   padding: 5px;
   justify-content: space-evenly;
 `;
-const BoardContent = ({ userPhoto, userName, date, content, photoContents, likes, commentsNum }) => {
-  return (
-    <>
-      <BoardContainer>
-        <BoardUserInfo>
-          <BoardUserImageContainer>
-            <BoardUserImage source={{ uri: userPhoto }} />
-          </BoardUserImageContainer>
-          <View style={{ flex: 1, padding: 5 }}>
-            <BoardUserName>{userName}</BoardUserName>
-            <Text>{date}</Text>
-          </View>
-        </BoardUserInfo>
-        <BoardContents>
-          <BoardContentTextContainer>
-            <Text>{content}</Text>
-          </BoardContentTextContainer>
-          <BoardContentImageContainer>
-            <BoardContentImage />
-            <BoardContentImage />
-            <BoardContentImage />
-          </BoardContentImageContainer>
-          <BoardTipContainer>
-            <TouchableOpacity>
-              <Text>Like {likes}</Text>
-            </TouchableOpacity>
-            <TouchableOpacity>
-              <Text>Comments {commentsNum}</Text>
-            </TouchableOpacity>
-          </BoardTipContainer>
-        </BoardContents>
-      </BoardContainer>
-    </>
-  );
-};
 
 const MindlePreview = ({ key, name, overlap }) => {
   const [tabIndex, setTabIndex] = useState(0);

--- a/client/src/screens/MindlePreview.js
+++ b/client/src/screens/MindlePreview.js
@@ -1,0 +1,231 @@
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import styled from 'styled-components/native';
+import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { FlatList } from 'react-native-gesture-handler';
+
+const Container = styled.SafeAreaView`
+  flex: 1;
+  display: flex;
+  padding: 15px 15px;
+  height: 100%;
+  background-color: #ffffff;
+  justify-content: flex-start;
+`;
+
+const Divider = styled.View`
+  margin-top: 10px;
+  height: 0.5px;
+  border: 0.5px solid #000000;
+`;
+const ImageContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  flex-flow: row wrap;
+  margin-top: 20px;
+`;
+
+const Image = styled.View`
+  border: 1px solid;
+  height: 80px;
+  width: 80px;
+  margin: 5px;
+`;
+
+const BoardContainer = styled.View`
+  height: 220px;
+
+  width: 100%;
+  padding: 10px 10px;
+  border-bottom-width: 1px;
+  border-bottom-color: black;
+`;
+const BoardUserInfo = styled.View`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+`;
+const BoardUserImageContainer = styled.View`
+  width: 50px;
+  height: 50px;
+  padding: 5px 5px;
+  align-items: center;
+  justify-content: center;
+`;
+const BoardUserImage = styled.Image`
+  width: 40px;
+  height: 40px;
+`;
+const BoardUserName = styled.Text`
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 3px;
+`;
+const BoardContents = styled.View`
+  padding-top: 10px;
+  padding-left: 55px;
+`;
+const BoardContentTextContainer = styled.View`
+  height: 50px;
+  justify-content: flex-start;
+`;
+const BoardContentImageContainer = styled.View`
+  margin-top: 5px;
+  margin-bottom: 5px;
+  height: 55px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+const BoardContentImage = styled.View`
+  border: 1px solid black;
+  width: 70px;
+  height: 55px;
+  margin-right: 10px;
+`;
+const BoardTipContainer = styled.View`
+  height: 30px;
+  padding-top: 5px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+const Tab = styled.View`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 50px;
+  padding: 5px;
+  justify-content: space-evenly;
+`;
+const BoardContent = ({ userPhoto, userName, date, content, photoContents, likes, commentsNum }) => {
+  return (
+    <>
+      <BoardContainer>
+        <BoardUserInfo>
+          <BoardUserImageContainer>
+            <BoardUserImage source={{ uri: userPhoto }} />
+          </BoardUserImageContainer>
+          <View style={{ flex: 1, padding: 5 }}>
+            <BoardUserName>{userName}</BoardUserName>
+            <Text>{date}</Text>
+          </View>
+        </BoardUserInfo>
+        <BoardContents>
+          <BoardContentTextContainer>
+            <Text>{content}</Text>
+          </BoardContentTextContainer>
+          <BoardContentImageContainer>
+            <BoardContentImage />
+            <BoardContentImage />
+            <BoardContentImage />
+          </BoardContentImageContainer>
+          <BoardTipContainer>
+            <TouchableOpacity>
+              <Text>Like {likes}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity>
+              <Text>Comments {commentsNum}</Text>
+            </TouchableOpacity>
+          </BoardTipContainer>
+        </BoardContents>
+      </BoardContainer>
+    </>
+  );
+};
+
+const MindlePreview = ({ key, name, overlap }) => {
+  const [tabIndex, setTabIndex] = useState(0);
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setData({
+      userPhoto:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Circle-icons-profile.svg/1024px-Circle-icons-profile.svg.png',
+      userName: '살찐 황소',
+      date: '2021-09-19',
+      content: '살찐 황소님이 작성한 글이에요~ 이건 예시 글이랍니다. 어떻게 나올지 궁금하네요~',
+      photoContents: ['', ''],
+      likes: 11,
+      commentsNum: 9,
+    });
+    return () => {
+      setData(null);
+    };
+  }, [key]);
+
+  useEffect(() => {
+    if (data) setLoading(false);
+  }, [data]);
+
+  return (
+    <>
+      <Container>
+        {/* <Header /> */}
+        <ImageContainer>
+          <Image></Image>
+          <Image></Image>
+          <Image></Image>
+          <Image></Image>
+          <Image></Image>
+          <Image></Image>
+          <Image></Image>
+          <Image></Image>
+        </ImageContainer>
+        <Tab>
+          <TouchableOpacity
+            onPress={() => {
+              setTabIndex(0);
+            }}
+            style={{
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '50%',
+              backgroundColor: tabIndex === 0 ? '#bdbdbd' : '#fefefe',
+            }}
+          >
+            <Text>게시글</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            disabled={true}
+            style={{
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '50%',
+              backgroundColor: tabIndex === 0 ? '#fefefe' : '#bdbdbd',
+            }}
+          >
+            <Text>이벤트</Text>
+          </TouchableOpacity>
+        </Tab>
+
+        <Divider />
+        {!loading && (
+          <>
+            <View style={{ flex: 1, justifyContent: 'flex-start' }}>
+              <BoardContent
+                userPhoto={data.userPhoto}
+                userName={data.userName}
+                date={data.date}
+                content={data.content}
+                photoContents={data.photoContents}
+                likes={data.likes}
+                commentsNum={data.commentsNum}
+              />
+              <View style={{ height: 50, width: '100%', justifyContent: 'center', alignItems: 'center' }}>
+                <Text>Locked</Text>
+              </View>
+            </View>
+          </>
+        )}
+        {loading && (
+          <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+            <ActivityIndicator size="large" color="0000ff" />
+          </View>
+        )}
+      </Container>
+    </>
+  );
+};
+export default MindlePreview;

--- a/client/src/screens/index.js
+++ b/client/src/screens/index.js
@@ -7,5 +7,6 @@ import HotSpot from './HotSpot';
 import Settings from './Settings';
 import Mypage from './Mypage';
 import MindleInfo from './MindleInfo';
+import MindlePreview from './MindlePreview';
 import MypageList from './MypageList';
-export { Login, Signup, Profile, Award, Maps, HotSpot, Settings, Mypage, MypageList, MindleInfo };
+export { Login, Signup, Profile, Award, Maps, HotSpot, Settings, Mypage, MypageList, MindleInfo, MindlePreview };


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- bottom sheet 내에서 무한 스크롤 구현
- bottom sheet 내에서 유저 사진 또는 이름 클릭 시 쪽지 보내기 Modal 오픈
- 민들레 반경 내에서 접근 시 보여줄 글쓰기 footer 버튼 추가 
- 민들레 반경 밖에서 접근 시 보여줄 미리보기 페이지 추가


<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- @components/Modal 에서 props 변경해서 width와 height를 설정해줄 수 있고, default는 width 300, height 200입니다. 앞으로 사용할 때 참고하시기 바랍니다.

<br/><br/>
